### PR TITLE
This closes #202 issue 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ Debug/*
 GccUnixR/*
 *.swp
 *.un~
-
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required (VERSION 2.8)
+  
+project(jwasm)
+
+include_directories(H)
+if (WIN32)
+set(CompilerFlags
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_DEBUG
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_C_FLAGS
+        CMAKE_C_FLAGS_DEBUG
+        CMAKE_C_FLAGS_RELEASE
+        )
+foreach(CompilerFlag ${CompilerFlags})
+  string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+endforeach()
+add_definitions(-D__NT__ -DNDEBUG -DDEBUG_OUT -D_CRT_SECURE_NO_WARNINGS)
+else()
+add_definitions(-D__UNIX__ -DNDEBUG -DDEBUG_OUT)
+endif()
+
+FILE(GLOB all_c_files *.c)
+add_executable(jwasm ${all_c_files})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,4 +21,5 @@ add_definitions(-D__UNIX__ -DNDEBUG -DDEBUG_OUT)
 endif()
 
 FILE(GLOB all_c_files *.c)
+LIST(REMOVE_ITEM all_c_files ${CMAKE_CURRENT_SOURCE_DIR}/trmem.c)
 add_executable(jwasm ${all_c_files})

--- a/H/globals.h
+++ b/H/globals.h
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <errno.h> /* needed for errno declaration ( "sometimes" it's defined in stdlib.h ) */
 
 #if defined(__UNIX__) || defined(__CYGWIN__) || defined(__DJGPP__) /* avoid for MinGW! */

--- a/invoke.c
+++ b/invoke.c
@@ -319,7 +319,7 @@ static int ms64_param( struct dsym const *proc, int index, struct dsym *param, b
 
             /* v2.06: support 64-bit constants for params > 4 */
             if ( psize == 8 &&
-                ( opnd->value64 > LONG_MAX || opnd->value64 < LONG_MIN ) ) {
+                ( opnd->value64 > INT32_MAX || opnd->value64 < INT32_MIN ) ) {
                 AddLineQueueX( " mov %r ptr [%r+%u], %r ( %s )", T_DWORD, T_RSP, NUMQUAL index*8, T_LOW32, paramvalue );
                 AddLineQueueX( " mov %r ptr [%r+%u], %r ( %s )", T_DWORD, T_RSP, NUMQUAL index*8+4, T_HIGH32, paramvalue );
 

--- a/parser.c
+++ b/parser.c
@@ -783,7 +783,7 @@ static ret_code idata_nofixup( struct code_info *CodeInfo, unsigned CurrOpnd, co
         CodeInfo->token == T_MOV &&
         CurrOpnd == OPND2 &&
         ( CodeInfo->opnd[OPND1].type & OP_R64 ) &&
-        ( opndx->value64 > LONG_MAX || opndx->value64 < LONG_MIN ||
+        ( opndx->value64 > INT32_MAX || opndx->value64 < INT32_MIN ||
          (opndx->explicit && ( opndx->mem_type == MT_QWORD || opndx->mem_type == MT_SQWORD ) ) ) ) {
         // CodeInfo->iswide = 1; /* has been set by first operand already */
         CodeInfo->opnd[CurrOpnd].type = OP_I64;
@@ -1075,7 +1075,7 @@ ret_code idata_fixup( struct code_info *CodeInfo, unsigned CurrOpnd, struct expr
 #if AMD64_SUPPORT
     case 8:
         /* v2.05: do only assume size 8 if the constant won't fit in 4 bytes. */
-        if ( opndx->value64 > LONG_MAX || opndx->value64 < LONG_MIN ||
+        if ( opndx->value64 > INT32_MAX || opndx->value64 < INT32_MIN ||
             (opndx->explicit && ( opndx->mem_type & MT_SIZE_MASK ) == 7 ) ) {
             CodeInfo->opnd[CurrOpnd].type = OP_I64;
             CodeInfo->opnd[CurrOpnd].data32h = opndx->hvalue;

--- a/trmem.c
+++ b/trmem.c
@@ -32,9 +32,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+//#include <string.h>
 #include <ctype.h>
-
+#include <errno.h>
 #if defined( _M_IX86 ) && defined(__WATCOMC__)
 #include <i86.h>
 #endif


### PR DESCRIPTION
This solves issue when building jwasm as x64 binary on linux/mac to properly handle mov reg, imm64. LONG_MIN/LONG_MAX are different from those on windows where long is always 4 bytes and where encoding works properly. Changing  LONG_MIN/LONG_MAX to INT32_MIN/INT32_MAX makes code to work properly on Linux/Mac.