### PR TITLE
This closes #202 issue when using x64 binaries on Linux/Mac to proper…

### DIFF
--- a/H/globals.h
+++ b/H/globals.h
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <errno.h> /* needed for errno declaration ( "sometimes" it's defined in stdlib.h ) */
 
 #if defined(__UNIX__) || defined(__CYGWIN__) || defined(__DJGPP__) /* avoid for MinGW! */

--- a/invoke.c
+++ b/invoke.c
@@ -319,7 +319,7 @@ static int ms64_param( struct dsym const *proc, int index, struct dsym *param, b
 
             /* v2.06: support 64-bit constants for params > 4 */
             if ( psize == 8 &&
-                ( opnd->value64 > LONG_MAX || opnd->value64 < LONG_MIN ) ) {
+                ( opnd->value64 > INT32_MAX || opnd->value64 < INT32_MIN ) ) {
                 AddLineQueueX( " mov %r ptr [%r+%u], %r ( %s )", T_DWORD, T_RSP, NUMQUAL index*8, T_LOW32, paramvalue );
                 AddLineQueueX( " mov %r ptr [%r+%u], %r ( %s )", T_DWORD, T_RSP, NUMQUAL index*8+4, T_HIGH32, paramvalue );
 

--- a/parser.c
+++ b/parser.c
@@ -783,7 +783,7 @@ static ret_code idata_nofixup( struct code_info *CodeInfo, unsigned CurrOpnd, co
         CodeInfo->token == T_MOV &&
         CurrOpnd == OPND2 &&
         ( CodeInfo->opnd[OPND1].type & OP_R64 ) &&
-        ( opndx->value64 > LONG_MAX || opndx->value64 < LONG_MIN ||
+        ( opndx->value64 > INT32_MAX || opndx->value64 < INT32_MIN ||
          (opndx->explicit && ( opndx->mem_type == MT_QWORD || opndx->mem_type == MT_SQWORD ) ) ) ) {
         // CodeInfo->iswide = 1; /* has been set by first operand already */
         CodeInfo->opnd[CurrOpnd].type = OP_I64;
@@ -1075,7 +1075,7 @@ ret_code idata_fixup( struct code_info *CodeInfo, unsigned CurrOpnd, struct expr
 #if AMD64_SUPPORT
     case 8:
         /* v2.05: do only assume size 8 if the constant won't fit in 4 bytes. */
-        if ( opndx->value64 > LONG_MAX || opndx->value64 < LONG_MIN ||
+        if ( opndx->value64 > INT32_MAX || opndx->value64 < INT32_MIN ||
             (opndx->explicit && ( opndx->mem_type & MT_SIZE_MASK ) == 7 ) ) {
             CodeInfo->opnd[CurrOpnd].type = OP_I64;
             CodeInfo->opnd[CurrOpnd].data32h = opndx->hvalue;


### PR DESCRIPTION
Fix issue #202 thus mov reg, imm64 can be properly produced when jwasm is compiled as x64 binary on mac and linux (problem is/was in LONG_MIN/MAX which is different between x32 and x64 builds)