### PR TITLE
add OpenBSD support, clean-up FreeBSD/APPLE #ifdef

### DIFF
--- a/H/memalloc.h
+++ b/H/memalloc.h
@@ -45,10 +45,8 @@ extern void MemFree( void *ptr );
 #elif defined(__GNUC__) || defined(__TINYC__)
 
 #define myalloca  alloca
-#ifndef __FreeBSD__  /* added v2.08 */
-#ifndef __APPLE__
-#include <malloc.h>  /* added v2.07 */
-#endif
+#if !(defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__))
+#include <malloc.h>
 #endif
 
 #elif defined(__PCC__)


### PR DESCRIPTION
OpenBSD-7.6 does not have <malloc.h>, need special care.
FreeBSD-14.2 has <malloc.h>, but there is no problem with current code.
NetBSD-current has <malloc.h>, nothing to do.
