### PR TITLE
Update bool.h

### DIFF
--- a/H/bool.h
+++ b/H/bool.h
@@ -29,8 +29,7 @@
 *
 ****************************************************************************/
 
-
-#if !defined( BOOL_DEFINED )  &&  !defined( bool ) && !(__WATCOMC__ >= 1070 && defined(__cplusplus))
+#if ( __STC_VERSION__ < 202311L ) && !defined( BOOL_DEFINED )  &&  !defined( bool ) && !( __WATCOMC__ >= 1070 && defined(__cplusplus) )
     #define BOOL_DEFINED
     typedef unsigned char bool;
 #endif


### PR DESCRIPTION
C23 introduces the bool literal, this causes compilation breakage here.

```
bool.h:35:27: error: 'bool' cannot be defined via 'typedef'
   35 |     typedef unsigned char bool;
      |                           ^~~~
bool.h:35:27: note: 'bool' is a keyword with '-std=c23' onwards
```