### PR TITLE
Update bool.h for c23

### DIFF
--- a/H/bool.h
+++ b/H/bool.h
@@ -29,7 +29,7 @@
 *
 ****************************************************************************/
 
-#if ( __STC_VERSION__ < 202311L ) && !defined( BOOL_DEFINED )  &&  !defined( bool ) && !( __WATCOMC__ >= 1070 && defined(__cplusplus) )
+#if ( __STDC_VERSION__ < 202311L ) && !defined( BOOL_DEFINED )  &&  !defined( bool ) && !( __WATCOMC__ >= 1070 && defined(__cplusplus) )
     #define BOOL_DEFINED
     typedef unsigned char bool;
 #endif

--- a/H/bool.h
+++ b/H/bool.h
@@ -29,8 +29,7 @@
 *
 ****************************************************************************/
 
-
-#if !defined( BOOL_DEFINED )  &&  !defined( bool ) && !(__WATCOMC__ >= 1070 && defined(__cplusplus))
+#if ( __STC_VERSION__ < 202311L ) && !defined( BOOL_DEFINED )  &&  !defined( bool ) && !( __WATCOMC__ >= 1070 && defined(__cplusplus) )
     #define BOOL_DEFINED
     typedef unsigned char bool;
 #endif


### PR DESCRIPTION
C23 introduces the bool literal, this causes compilation breakage here.

Before this change:
https://godbolt.org/z/6z4z3vMoo
```
<source>:4:27: error: 'bool' cannot be defined via 'typedef'
    4 |     typedef unsigned char bool;
      |                           ^~~~
<source>:4:27: note: 'bool' is a keyword with '-std=c23' onwards
<source>:4:5: warning: useless type name in empty declaration
    4 |     typedef unsigned char bool;
      |     ^~~~~~~
Compiler returned: 1
```

After this change:
https://godbolt.org/z/7EGWj7PbP
```
Compiler returned: 0
```

